### PR TITLE
Parse HTML as documents rather than fragments

### DIFF
--- a/lib/dream_livereload.ml
+++ b/lib/dream_livereload.ml
@@ -58,7 +58,12 @@ let inject_script
   match Dream.header "Content-Type" response with
   | Some "text/html" | Some "text/html; charset=utf-8" ->
     let%lwt body = Dream.body response in
-    let soup = Soup.parse body in
+    let soup =
+      Markup.string body
+      |> Markup.parse_html ~context:`Document
+      |> Markup.signals
+      |> Soup.from_signals
+    in
     let open Soup.Infix in
     (match soup $? "head" with
     | None ->


### PR DESCRIPTION
Fixes #1.

Without this PR, if you run the example, you will see from the server logs that it never tries to open a WebSocket. With this fix, the server correctly inserts the live reload script into the example's HTML's implied `<head>`, and the example does try to open the socket.