### PR TITLE
Add /_livereload route in the example

### DIFF
--- a/example/server.ml
+++ b/example/server.ml
@@ -4,5 +4,8 @@ let () =
   Dream.run ~debug:true
   @@ Dream.logger
   @@ Dream_livereload.inject_script ()
-  @@ Dream.router [ Dream.get "/" (fun _ -> Dream.html "Hello World!") ]
+  @@ Dream.router [
+    Dream.get "/" (fun _ -> Dream.html "Hello World!");
+    Dream_livereload.route ();
+  ]
   @@ Dream.not_found


### PR DESCRIPTION
The example server doesn't work without this PR, because it doesn't actually have the `/_livereload` route.